### PR TITLE
Use pkg-config to resolve r_core

### DIFF
--- a/api.go
+++ b/api.go
@@ -4,6 +4,7 @@ package r2pipe
 
 // #cgo CFLAGS: -I/usr/local/include/libr
 // #cgo CFLAGS: -I/usr/local/include/libr/sdb
+// #cgo LDFLAGS: -L/usr/local/lib -lr_core
 // #cgo pkg-config: r_core
 // #include <stdio.h>
 // #include <stdlib.h>

--- a/api.go
+++ b/api.go
@@ -4,7 +4,7 @@ package r2pipe
 
 // #cgo CFLAGS: -I/usr/local/include/libr
 // #cgo CFLAGS: -I/usr/local/include/libr/sdb
-// #cgo LDFLAGS: -L/usr/local/lib -lr_core
+// #cgo pkg-config: r_core
 // #include <stdio.h>
 // #include <stdlib.h>
 // extern void r_core_free(void *);


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

In the situations where the `r_core` is not present inside the `/usr/local/lib` but is instead managed by the `pkg-config`, the build will fail. The solution is to use `#cgo pkg-config` which this PR does